### PR TITLE
Use custom names for the object tagger alerts and move the trimmer on…

### DIFF
--- a/src/batch_job_handler_lambda/batch_job_handler.py
+++ b/src/batch_job_handler_lambda/batch_job_handler.py
@@ -335,7 +335,9 @@ def get_slack_channel_override(
         )
         return None
 
-    if REGEX_COALESCER_JOB_QUEUE_ARN.match(job_queue) or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
+    if REGEX_COALESCER_JOB_QUEUE_ARN.match(
+        job_queue
+    ) or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
         logger.info(
             f'Using slack channel override for job", "slack_channel_override": "{slack_channel_override}", '
             + f'"job_queue": "{job_queue}", "job_name": "{job_name}", "job_status": "{job_status}'

--- a/src/batch_job_handler_lambda/batch_job_handler.py
+++ b/src/batch_job_handler_lambda/batch_job_handler.py
@@ -282,7 +282,18 @@ def get_friendly_name(
     friendly_name = "Batch job"
 
     if REGEX_PDM_OBJECT_TAGGING_JOB_QUEUE_ARN.match(job_queue):
-        friendly_name = "PDM object tagger"
+        if "_pt_1" in job_name.lower():
+            friendly_name = "PT-1 object tagger"
+        elif "_pt_2" in job_name.lower():
+            friendly_name = "PT-2 object tagger"
+        elif "pt-" in job_name.lower():
+            friendly_name = "PT object tagger"
+        elif "clive" in job_name.lower():
+            friendly_name = "Clive object tagger"
+        elif "pdm" in job_name.lower():
+            friendly_name = "PDM object tagger"
+        else:
+            friendly_name = "Object tagger"
     elif REGEX_UCFS_CLAIMANT_JOB_QUEUE_ARN.match(job_queue):
         friendly_name = "UCFS claimant data load"
     elif REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
@@ -324,9 +335,9 @@ def get_slack_channel_override(
         )
         return None
 
-    if REGEX_COALESCER_JOB_QUEUE_ARN.match(job_queue):
+    if REGEX_COALESCER_JOB_QUEUE_ARN.match(job_queue) or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
         logger.info(
-            f'Using slack channel override for coalescer job", "slack_channel_override": "{slack_channel_override}", '
+            f'Using slack channel override for job", "slack_channel_override": "{slack_channel_override}", '
             + f'"job_queue": "{job_queue}", "job_name": "{job_name}", "job_status": "{job_status}'
         )
         return slack_channel_override

--- a/tests/test_batch_job_handler.py
+++ b/tests/test_batch_job_handler.py
@@ -34,6 +34,7 @@ CRITICAL_SEVERITY = "Critical"
 HIGH_SEVERITY = "High"
 MEDIUM_SEVERITY = "Medium"
 
+TRIMMER_JOB_QUEUE = "test/k2hb_reconciliation_trimmer"
 COALECSER_JOB_QUEUE = "test/batch_corporate_storage_coalescer"
 PDM_JOB_QUEUE = "test/pdm_object_tagger"
 OTHER_JOB_QUEUE = "test_queue"
@@ -639,11 +640,61 @@ class TestRetriever(unittest.TestCase):
         self.assertEqual(expected_payload, actual_payload)
 
     @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
-    def test_get_friendly_name_returns_a_matched_name(self, mock_logger):
+    def test_get_friendly_name_returns_pdm_matched_name(self, mock_logger):
         expected = "PDM object tagger"
         actual = batch_job_handler.get_friendly_name(
             PDM_JOB_QUEUE,
-            JOB_NAME,
+            "pdM-test-job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_clive_matched_name(self, mock_logger):
+        expected = "Clive object tagger"
+        actual = batch_job_handler.get_friendly_name(
+            PDM_JOB_QUEUE,
+            "clIvE-test-job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_pt_matched_name(self, mock_logger):
+        expected = "PT object tagger"
+        actual = batch_job_handler.get_friendly_name(
+            PDM_JOB_QUEUE,
+            "clive-Pt-_job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_pt_1_matched_name(self, mock_logger):
+        expected = "PT-1 object tagger"
+        actual = batch_job_handler.get_friendly_name(
+            PDM_JOB_QUEUE,
+            "pdm_Pt_1_job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_pt_2_matched_name(self, mock_logger):
+        expected = "PT-2 object tagger"
+        actual = batch_job_handler.get_friendly_name(
+            PDM_JOB_QUEUE,
+            "pdm_Pt_2_job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_a_matched_name(self, mock_logger):
+        expected = "Object tagger"
+        actual = batch_job_handler.get_friendly_name(
+            PDM_JOB_QUEUE,
+            "job-name",
             FAILED_JOB_STATUS,
         )
         self.assertEqual(expected, actual)
@@ -690,6 +741,19 @@ class TestRetriever(unittest.TestCase):
         actual = batch_job_handler.get_slack_channel_override(
             MOCK_CHANNEL,
             COALECSER_JOB_QUEUE,
+            JOB_NAME,
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_slack_channel_override_returns_override_for_trimmer_queue(
+        self, mock_logger
+    ):
+        expected = MOCK_CHANNEL
+        actual = batch_job_handler.get_slack_channel_override(
+            MOCK_CHANNEL,
+            TRIMMER_JOB_QUEUE,
             JOB_NAME,
             FAILED_JOB_STATUS,
         )


### PR DESCRIPTION
DW-6014 Use custom names for the object tagger alerts and move the trimmer ones (they are utility) out of main production alerts channel