### PR TITLE
Send Kafka batch jobs to batch slack channel and remove uc feature code as no object tagging anymore for that product

### DIFF
--- a/src/batch_job_handler_lambda/batch_job_handler.py
+++ b/src/batch_job_handler_lambda/batch_job_handler.py
@@ -43,6 +43,7 @@ REGEX_OBJECT_TAGGING_JOB_QUEUE_ARN = re.compile("^.*/.*_object_tagger$")
 REGEX_UCFS_CLAIMANT_JOB_QUEUE_ARN = re.compile("^.*/ucfs_claimant_api$")
 REGEX_TRIMMER_JOB_QUEUE_ARN = re.compile("^.*/k2hb_reconciliation_trimmer$")
 REGEX_COALESCER_JOB_QUEUE_ARN = re.compile("^.*/batch_corporate_storage_coalescer.*$")
+REGEX_KAFKA_RECONCILIATION_JOB_QUEUE_ARN = re.compile("^.*/kafka-reconciliation$")
 
 args = None
 logger = None
@@ -292,8 +293,6 @@ def get_friendly_name(
             friendly_name = "Clive object tagger"
         elif "pdm" in job_name.lower():
             friendly_name = "PDM object tagger"
-        elif "uc-feature" in job_name.lower():
-            friendly_name = "UC feature object tagger"
         else:
             friendly_name = "Object tagger"
     elif REGEX_UCFS_CLAIMANT_JOB_QUEUE_ARN.match(job_queue):
@@ -302,6 +301,8 @@ def get_friendly_name(
         friendly_name = "K2HB trimmer"
     elif REGEX_COALESCER_JOB_QUEUE_ARN.match(job_queue):
         friendly_name = "Batch coalescer"
+    elif REGEX_KAFKA_RECONCILIATION_JOB_QUEUE_ARN.match(job_queue):
+        friendly_name = "Kafka reconciliation batch"
 
     logger.info(
         f'Generated job queue friendly name", "friendly_name": "{friendly_name}", '
@@ -338,6 +339,8 @@ def get_slack_channel_override(
         return None
 
     if REGEX_COALESCER_JOB_QUEUE_ARN.match(
+        job_queue
+    ) or REGEX_KAFKA_RECONCILIATION_JOB_QUEUE_ARN.match(
         job_queue
     ) or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
         logger.info(

--- a/src/batch_job_handler_lambda/batch_job_handler.py
+++ b/src/batch_job_handler_lambda/batch_job_handler.py
@@ -338,11 +338,11 @@ def get_slack_channel_override(
         )
         return None
 
-    if REGEX_COALESCER_JOB_QUEUE_ARN.match(
-        job_queue
-    ) or REGEX_KAFKA_RECONCILIATION_JOB_QUEUE_ARN.match(
-        job_queue
-    ) or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue):
+    if (
+        REGEX_COALESCER_JOB_QUEUE_ARN.match(job_queue)
+        or REGEX_KAFKA_RECONCILIATION_JOB_QUEUE_ARN.match(job_queue)
+        or REGEX_TRIMMER_JOB_QUEUE_ARN.match(job_queue)
+    ):
         logger.info(
             f'Using slack channel override for job", "slack_channel_override": "{slack_channel_override}", '
             + f'"job_queue": "{job_queue}", "job_name": "{job_name}", "job_status": "{job_status}'

--- a/tests/test_batch_job_handler.py
+++ b/tests/test_batch_job_handler.py
@@ -36,6 +36,7 @@ MEDIUM_SEVERITY = "Medium"
 
 TRIMMER_JOB_QUEUE = "test/k2hb_reconciliation_trimmer"
 COALECSER_JOB_QUEUE = "test/batch_corporate_storage_coalescer"
+KAFKA_JOB_QUEUE = "test/kafka-reconciliation"
 PDM_JOB_QUEUE = "test/pdm_object_tagger"
 PT_JOB_QUEUE = "test/pt_object_tagger"
 OTHER_JOB_QUEUE = "test_queue"
@@ -662,16 +663,6 @@ class TestRetriever(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
-    def test_get_friendly_name_returns_uc_feature_matched_name(self, mock_logger):
-        expected = "UC feature object tagger"
-        actual = batch_job_handler.get_friendly_name(
-            PDM_JOB_QUEUE,
-            "uc-feature-test-job-name",
-            FAILED_JOB_STATUS,
-        )
-        self.assertEqual(expected, actual)
-
-    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
     def test_get_friendly_name_returns_clive_matched_name(self, mock_logger):
         expected = "Clive object tagger"
         actual = batch_job_handler.get_friendly_name(
@@ -719,6 +710,16 @@ class TestRetriever(unittest.TestCase):
         actual = batch_job_handler.get_friendly_name(
             PDM_JOB_QUEUE,
             "pdm_Pt_2_job-name",
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_friendly_name_returns_kafka_matched_name(self, mock_logger):
+        expected = "Kafka reconciliation batch"
+        actual = batch_job_handler.get_friendly_name(
+            KAFKA_JOB_QUEUE,
+            "kafka_job_name",
             FAILED_JOB_STATUS,
         )
         self.assertEqual(expected, actual)
@@ -788,6 +789,19 @@ class TestRetriever(unittest.TestCase):
         actual = batch_job_handler.get_slack_channel_override(
             MOCK_CHANNEL,
             TRIMMER_JOB_QUEUE,
+            JOB_NAME,
+            FAILED_JOB_STATUS,
+        )
+        self.assertEqual(expected, actual)
+
+    @mock.patch("batch_job_handler_lambda.batch_job_handler.logger")
+    def test_get_slack_channel_override_returns_override_for_kafka_queue(
+        self, mock_logger
+    ):
+        expected = MOCK_CHANNEL
+        actual = batch_job_handler.get_slack_channel_override(
+            MOCK_CHANNEL,
+            KAFKA_JOB_QUEUE,
             JOB_NAME,
             FAILED_JOB_STATUS,
         )


### PR DESCRIPTION
Send Kafka batch jobs to batch slack channel and remove uc feature code as no object tagging anymore for that product